### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 MCP Server for the Mapbox API.
 
+<a href="https://glama.ai/mcp/servers/ijqo60lj52"><img width="380" height="200" src="https://glama.ai/mcp/servers/ijqo60lj52/badge" alt="mapbox-mcp-server MCP server" /></a>
+
 ## Features
 
 ### Navigation Tools


### PR DESCRIPTION
This PR adds a badge for the mapbox-mcp-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ijqo60lj52"><img width="380" height="200" src="https://glama.ai/mcp/servers/ijqo60lj52/badge" alt="mapbox-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.